### PR TITLE
Update adapters to send messages directly

### DIFF
--- a/message/package.json
+++ b/message/package.json
@@ -7,7 +7,8 @@
     "dev": "nodemon --exec ts-node -r tsconfig-paths/register src/main.ts"
   },
   "dependencies": {
-    "node-telegram-bot-api": "^0.61.0"
+    "node-telegram-bot-api": "^0.61.0",
+    "nodemailer": "^6.9.11"
   },
   "devDependencies": {
     "@types/node": "^24.0.1",

--- a/message/src/adapters/email.adapter.ts
+++ b/message/src/adapters/email.adapter.ts
@@ -1,13 +1,26 @@
-import { MultiEventBus } from '@event-bus';
-import { NOTIFY_SEND_EMAIL } from '@config/common/bus.topics';
+import nodemailer from 'nodemailer';
+import { ConfigService } from '@config';
 import { NotificationAdapter, TemplateConfig } from './notification-adapter';
 
 export class EmailAdapter implements NotificationAdapter {
   readonly name = 'email';
-  constructor(private bus: MultiEventBus) {}
+  private transporter: nodemailer.Transporter;
+
+  constructor(private config: ConfigService) {
+    this.transporter = nodemailer.createTransport({
+      host: config.getString('SMTP_HOST'),
+      port: Number(config.getString('SMTP_PORT', '587')),
+      secure: false,
+      auth: {
+        user: config.getString('SMTP_USER'),
+        pass: config.getString('SMTP_PASS'),
+      },
+    });
+  }
 
   async send(userId: string, template: TemplateConfig): Promise<void> {
-    await this.bus.publish(NOTIFY_SEND_EMAIL, {
+    await this.transporter.sendMail({
+      from: this.config.getString('SMTP_FROM', ''),
       to: userId,
       subject: template.subject || '',
       html: template.body,

--- a/message/src/adapters/telegram.adapter.ts
+++ b/message/src/adapters/telegram.adapter.ts
@@ -1,14 +1,18 @@
+import TelegramBot from 'node-telegram-bot-api';
+import { ConfigService } from '@config';
 import { NotificationAdapter, TemplateConfig } from './notification-adapter';
-import { TelegramService } from '../common/telegram.service';
 
 export class TelegramAdapter implements NotificationAdapter {
   readonly name = 'telegram';
-  constructor(private telegram: TelegramService) {}
+  private bot: TelegramBot;
+
+  constructor(config: ConfigService) {
+    this.bot = new TelegramBot(config.getString('TELEGRAM_BOT_TOKEN'), {
+      polling: false,
+    });
+  }
 
   async send(userId: string, template: TemplateConfig): Promise<void> {
-    await this.telegram.sendMessage({
-      chatId: userId,
-      text: template.body,
-    });
+    await this.bot.sendMessage(userId, template.body);
   }
 }

--- a/message/src/message.service.ts
+++ b/message/src/message.service.ts
@@ -56,10 +56,10 @@ export class MessageService {
     for (const name of list) {
       switch (name) {
         case 'email':
-          this.registerAdapter(new EmailAdapter(this.multiBus));
+          this.registerAdapter(new EmailAdapter(this.config));
           break;
         case 'telegram':
-          this.registerAdapter(new TelegramAdapter(this.telegramService));
+          this.registerAdapter(new TelegramAdapter(this.config));
           break;
         default:
           console.warn(`[MessageService] Unknown adapter ${name}`);


### PR DESCRIPTION
## Summary
- embed telegram client directly in `TelegramAdapter`
- update `MessageService` registration to use the new adapter

## Testing
- `npx tsc --noEmit` *(fails: Cannot read file '/workspace/tsconfig.base.json')*

------
https://chatgpt.com/codex/tasks/task_e_68624122362c832e88afd3804d610ce4