### PR TITLE
Add websocket broadcast and private message adapters

### DIFF
--- a/message/src/adapters/private-message.adapter.ts
+++ b/message/src/adapters/private-message.adapter.ts
@@ -1,15 +1,15 @@
 import { NotificationAdapter, TemplateConfig } from './notification-adapter';
 import { SocketService } from '../common/socket.service';
 
-export class BroadcastAdapter implements NotificationAdapter {
-  readonly name = 'broadcast';
+export class PrivateMessageAdapter implements NotificationAdapter {
+  readonly name = 'private';
   private socket: SocketService;
 
   constructor() {
     this.socket = SocketService.getInstance();
   }
 
-  async send(_: string, template: TemplateConfig): Promise<void> {
-    this.socket.sendBroadcastMessage({ data: template.body });
+  async send(userId: string, template: TemplateConfig): Promise<void> {
+    this.socket.sendPrivateMessage({ user: userId, data: template.body });
   }
 }

--- a/message/src/message.service.ts
+++ b/message/src/message.service.ts
@@ -6,6 +6,8 @@ import { NOTIFIER_DISPATCH_EVENT, TELEGRAM_SEND_MESSAGE } from '@config/common/b
 import type { TemplateConfig, NotificationAdapter } from './adapters/notification-adapter';
 import { EmailAdapter } from './adapters/email.adapter';
 import { TelegramAdapter } from './adapters/telegram.adapter';
+import { BroadcastAdapter } from './adapters/broadcast-adapter';
+import { PrivateMessageAdapter } from './adapters/private-message.adapter';
 import { TelegramService, TelegramMessagePayload } from './common/telegram.service';
 
 interface NotifyEvent {
@@ -49,7 +51,7 @@ export class MessageService {
   }
 
   private registerEnvAdapters() {
-    const list = this.config.getString('MESSAGE_ADAPTERS', 'email,telegram')
+    const list = this.config.getString('MESSAGE_ADAPTERS', 'email,telegram,broadcast,private')
       .split(',')
       .map(a => a.trim())
       .filter(Boolean);
@@ -60,6 +62,12 @@ export class MessageService {
           break;
         case 'telegram':
           this.registerAdapter(new TelegramAdapter(this.telegramService));
+          break;
+        case 'broadcast':
+          this.registerAdapter(new BroadcastAdapter());
+          break;
+        case 'private':
+          this.registerAdapter(new PrivateMessageAdapter());
           break;
         default:
           console.warn(`[MessageService] Unknown adapter ${name}`);


### PR DESCRIPTION
## Summary
- implement BroadcastAdapter to send websocket messages to all connections
- add PrivateMessageAdapter for one-to-one websocket messages
- register new adapters in the message service

## Testing
- `npx tsc -p message/tsconfig.json --noEmit` *(fails: Cannot read file '/workspace/tsconfig.base.json' and libs)*

------
https://chatgpt.com/codex/tasks/task_e_686263450b58832eac7c65de0f17692c