### PR TITLE
Add Twilio SMS adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # message
+
+This service dispatches notifications using multiple adapters.
+
+## Available adapters
+
+- email
+- telegram
+- broadcast
+- private
+- whatsapp
+- sms (Twilio)

--- a/message/package.json
+++ b/message/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "node-telegram-bot-api": "^0.61.0",
-    "axios": "^1.6.7"
+    "axios": "^1.6.7",
+    "twilio": "^4.21.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.1",

--- a/message/src/adapters/sms.adapter.ts
+++ b/message/src/adapters/sms.adapter.ts
@@ -1,0 +1,12 @@
+import { NotificationAdapter } from './notification-adapter';
+import { SmsService } from '../common/sms.service';
+
+export class SmsAdapter implements NotificationAdapter {
+  readonly name = 'sms';
+
+  constructor(private sms: SmsService) {}
+
+  async send(address: string, message: string): Promise<void> {
+    await this.sms.sendMessage({ to: address, text: message });
+  }
+}

--- a/message/src/common/sms.service.ts
+++ b/message/src/common/sms.service.ts
@@ -1,0 +1,27 @@
+import { ConfigService } from '@config';
+import twilio from 'twilio';
+
+export interface SmsMessagePayload {
+  to: string;
+  text: string;
+}
+
+export class SmsService {
+  private client: twilio.Twilio;
+  private from: string;
+
+  constructor(private config: ConfigService) {
+    const accountSid = config.getString('TWILIO_ACCOUNT_SID');
+    const authToken = config.getString('TWILIO_AUTH_TOKEN');
+    this.from = config.getString('TWILIO_FROM_NUMBER');
+    this.client = twilio(accountSid, authToken);
+  }
+
+  async sendMessage(payload: SmsMessagePayload): Promise<void> {
+    await this.client.messages.create({
+      body: payload.text,
+      from: this.from,
+      to: payload.to,
+    });
+  }
+}

--- a/message/src/message.service.ts
+++ b/message/src/message.service.ts
@@ -7,8 +7,10 @@ import {TelegramAdapter} from './adapters/telegram.adapter';
 import {BroadcastAdapter} from './adapters/broadcast-adapter';
 import {PrivateMessageAdapter} from './adapters/private-message.adapter';
 import {WhatsAppAdapter} from './adapters/whatsapp.adapter';
+import {SmsAdapter} from './adapters/sms.adapter';
 import {TelegramService} from './common/telegram.service';
 import {WhatsAppService} from './common/whatsapp.service';
+import {SmsService} from './common/sms.service';
 import {SocketService} from './common/socket.service';
 
 interface NotifyEvent {
@@ -23,12 +25,14 @@ export class MessageService {
   private telegramService: TelegramService;
   private whatsappService: WhatsAppService;
   private socketService: SocketService;
+  private smsService: SmsService;
 
   constructor(config: ConfigService) {
     this.config = config;
     this.telegramService = new TelegramService(config);
     this.whatsappService = new WhatsAppService(config);
     this.socketService = new SocketService();
+    this.smsService = new SmsService(config);
   }
 
   async start() {
@@ -47,7 +51,7 @@ export class MessageService {
   }
 
   private registerEnvAdapters() {
-    const list = this.config.getString('MESSAGE_ADAPTERS', 'email,telegram,broadcast,private,whatsapp')
+    const list = this.config.getString('MESSAGE_ADAPTERS', 'email,telegram,broadcast,private,whatsapp,sms')
       .split(',')
       .map(a => a.trim())
       .filter(Boolean);
@@ -67,6 +71,9 @@ export class MessageService {
           break;
         case 'whatsapp':
           this.registerAdapter(new WhatsAppAdapter(this.whatsappService));
+          break;
+        case 'sms':
+          this.registerAdapter(new SmsAdapter(this.smsService));
           break;
         default:
           console.warn(`[MessageService] Unknown adapter ${name}`);


### PR DESCRIPTION
## Summary
- support sending SMS messages through Twilio
- expose an `SmsService` for Twilio API calls
- register the new adapter in `MessageService`
- document all available adapters
- add `twilio` dependency

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68627f91bec8832ebb96d811fd3446d8